### PR TITLE
Fix bug in StaticUserRepository.cs (en verbeter enkele typfouten)

### DIFF
--- a/Exercises/Pages/Lesson1/README.md
+++ b/Exercises/Pages/Lesson1/README.md
@@ -218,10 +218,10 @@ In het onderstaande voorbeeld is te zien hoe je een `Guid` kan gebruiken. Een `G
     var guid = Guid.NewGuid();
     
     //convert Guid to String
-    var guisAsString = guid.ToString();
+    var guidAsString = guid.ToString();
     
     //convert string to Guid
-    var guidFromSTring = new Guid(guidAsString);
+    var guidFromString = new Guid(guidAsString);
 ```
 
 - Login.cshtml - Inlog Pagina.  

--- a/Exercises/Pages/Lesson1/Repository/StaticUserRepository.cs
+++ b/Exercises/Pages/Lesson1/Repository/StaticUserRepository.cs
@@ -20,7 +20,7 @@ namespace Exercises.Pages.Lesson1.Repository
         {
             if (cafeUser.UniqueGuid == default(Guid))
             {
-                cafeUser.UniqueGuid = new Guid();
+                cafeUser.UniqueGuid = Guid.NewGuid();
             }
             
             if (_users.Find(x => x.UniqueGuid == cafeUser.UniqueGuid) != null)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ git stash
 git pull
 git stash pop
 ```
-* Een alternatief is dat je gewoon opnieuw het repostipry kloont en verder werkt in deze directory. 
+* Een alternatief is dat je gewoon opnieuw het repository kloont en verder werkt in deze directory. 
 ```bash 
 git clone https://github.com/jorislops/WebdevCourseRazorPages.git <newDirectory>
 ```


### PR DESCRIPTION
In het bestand StaticUserRepository.cs onder Lesson1 staat momenteel de regel `cafeUser.UniqueGuid = new Guid();`, dit zorgt voor een bug wanneer het bestand letterlijk wordt overgenomen aangezien `new Guid()` altijd de default waarde zal hebben. Dit moet natuurlijk `cafeUser.UniqueGuid = Guid.NewGuid();` zijn.